### PR TITLE
Ignore local Copilot testing instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ installer/*.zip
 test-*.ps1
 
 # Local Configuration
+.github/copilot-instructions.md
 config.local.json
 .claude/settings.local.json
 .claude/maeinomatic-foundry-mcp-server-*.zip


### PR DESCRIPTION
## Summary

Adds `.github/copilot-instructions.md` to `.gitignore` so contributors can keep machine-specific Foundry runtime testing guidance locally without committing it.

The local instruction file is intentionally untracked and is not included in this PR.