### PR TITLE
Ignore local Foundry runtime testing instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,7 @@
+# Project Validation Guidance
+
+## CI checks
+
+- After editing TypeScript, JavaScript, JSON, or Markdown, run `npm run format:check` before reporting the work complete. If it fails, run `npm run format`, review the resulting diff, and rerun the check.
+- When production dependencies or dependency overrides change, run `npm run audit:prod`.
+- Do not broadly suppress production-audit findings. Any exception must be narrowly scoped to a specific advisory and documented upstream compatibility constraint.

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ installer/*.zip
 test-*.ps1
 
 # Local Configuration
+.github/instructions/local-foundry-runtime-testing.instructions.md
 config.local.json
 .claude/settings.local.json
 .claude/maeinomatic-foundry-mcp-server-*.zip


### PR DESCRIPTION
## Summary

Adds a narrow local configuration ignore rule for `.github/instructions/local-foundry-runtime-testing.instructions.md`.

This keeps machine-specific Foundry validation instructions out of commits while leaving `.github/copilot-instructions.md` available for future shared, committed Copilot guidance.

Supersedes closed PR #43, which was closed in error.